### PR TITLE
fix: Dockerfile の静的ファイル COPY パスを修正

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -58,8 +58,8 @@ Thumbs.db
 # Agent ログ
 .agents/
 
-# 既存の static（Docker ビルド時に images/ から作成）
-static/
+# static 内の不要ファイルのみ除外（logo.png 等は含める）
+# static/
 
 # main.py は不要（CLI ツール）
 main.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ COPY app.py ./
 COPY templates ./templates
 COPY pyproject.toml ./
 
-# 静的ファイル（ロゴ）をコピー
-COPY images/logo.png ./static/images/logo.png
+# 静的ファイルをコピー
+COPY static ./static
 
 # 仮想環境の Python を PATH に追加
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
## Summary
- Dockerfile の `COPY images/logo.png` が存在しないパスを参照しビルド失敗していた問題を修正
- 実際のディレクトリ構成 (`static/images/logo.png`) に合わせ `COPY static ./static` に変更
- `.dockerignore` で `static/` ディレクトリを除外していた設定を解除

## Test plan
- [ ] `docker build .` が正常に完了することを確認
- [ ] ビルドしたコンテナで `/static/images/logo.png` が配置されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)